### PR TITLE
feat: supporting learner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,9 +216,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CPP_FLAGS} -O2 -pipe -Wall -W -fPIC 
 
 macro(use_cxx11)
 if(CMAKE_VERSION VERSION_LESS "3.1.3")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 else()
-    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 14)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 endmacro(use_cxx11)

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -1884,6 +1884,9 @@ void NodeImpl::step_down(const int64_t term, bool wakeup_a_candidate,
         }
     }
 
+    // clear all learners' address.
+    _learners.reset();
+
     // stop stagging new node
     if (wakeup_a_candidate) {
         _replicator_group.stop_all_and_find_the_next_candidate(

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -141,6 +141,8 @@ public:
     void change_peers(const Configuration& new_peers, Closure* done);
     butil::Status reset_peers(const Configuration& new_peers);
 
+    void add_learner(const PeerId& peer, Closure* done);
+
     // trigger snapshot
     void snapshot(Closure* done);
 
@@ -496,6 +498,7 @@ private:
     VoteBallotCtx _vote_ctx; // candidate vote ctx
     VoteBallotCtx _pre_vote_ctx; // prevote ctx
     ConfigurationEntry _conf;
+    Configuration _learners;
 
     GroupId _group_id;
     VersionedGroupId _v_group_id;

--- a/src/braft/raft.cpp
+++ b/src/braft/raft.cpp
@@ -198,6 +198,10 @@ void Node::change_peers(const Configuration& new_peers, Closure* done) {
     _impl->change_peers(new_peers, done);
 }
 
+void Node::add_learner(const PeerId &peer, Closure *done) {
+    _impl->add_learner(peer, done);
+}
+
 butil::Status Node::reset_peers(const Configuration& new_peers) {
     return _impl->reset_peers(new_peers);
 }

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -269,6 +269,7 @@ public:
 
 enum State {
     // Don't change the order if you are not sure about the usage.
+    STATE_LEARNER = 0,
     STATE_LEADER = 1,
     STATE_TRANSFERRING = 2,
     STATE_CANDIDATE = 3,
@@ -607,6 +608,8 @@ struct NodeOptions {
     NodeOptions();
 
     int get_catchup_timeout_ms();
+
+    bool is_learner = false;
 };
 
 inline NodeOptions::NodeOptions() 
@@ -698,6 +701,11 @@ public:
     // would be invoked after this operation finishes, describing the detailed
     // result.
     void change_peers(const Configuration& new_peers, Closure* done);
+    
+    // Add a new learner to the raft group. done->Run() would be invoked after this
+    // operation finishes, describing the detailed result.
+    // [NOTE] learner is a special peer, it will not vote and not participate in leader election.
+    void add_learner(const PeerId& peer, Closure* done);
 
     // Reset the configuration of this node individually, without any repliation
     // to other peers before this node beomes the leader. This function is

--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -486,9 +486,12 @@ void Replicator::_on_rpc_returned(ReplicatorId id, brpc::Controller* cntl,
                                     << rpc_last_log_index
                                     << "] to peer " << r->_options.peer_id;
     if (entries_size > 0) {
-        r->_options.ballot_box->commit_at(
-                min_flying_index, rpc_last_log_index,
-                r->_options.peer_id);
+        if (!r->_options.is_learner) {
+            r->_options.ballot_box->commit_at(
+                    min_flying_index, rpc_last_log_index,
+                    r->_options.peer_id);
+        }
+
         int64_t rpc_latency_us = cntl->latency_us();
         if (FLAGS_raft_trace_append_entry_latency && 
             rpc_latency_us > FLAGS_raft_append_entry_high_lat_us) {
@@ -1388,10 +1391,11 @@ int ReplicatorGroup::init(const NodeId& node_id, const ReplicatorGroupOptions& o
     _common_options.snapshot_storage = options.snapshot_storage;
     _common_options.snapshot_throttle = options.snapshot_throttle;
     _common_options.replicator_status = NULL;
+    _common_options.is_learner = false;
     return 0;
 }
 
-int ReplicatorGroup::add_replicator(const PeerId& peer) {
+int ReplicatorGroup::add_replicator(const PeerId& peer, bool is_learner) {
     CHECK_NE(0, _common_options.term);
     if (_rmap.find(peer) != _rmap.end()) {
         return 0;
@@ -1399,6 +1403,7 @@ int ReplicatorGroup::add_replicator(const PeerId& peer) {
     ReplicatorOptions options = _common_options;
     options.peer_id = peer;
     options.replicator_status = new ReplicatorStatus;
+    options.is_learner = is_learner;
     ReplicatorId rid;
     if (Replicator::start(options, &rid) != 0) {
         LOG(ERROR) << "Group " << options.group_id

--- a/src/braft/replicator.h
+++ b/src/braft/replicator.h
@@ -22,6 +22,7 @@
 #include <bthread/bthread.h>                            // bthread_id
 #include <brpc/channel.h>                  // brpc::Channel
 
+#include "braft/file_system_adaptor.h"
 #include "braft/storage.h"                       // SnapshotStorage
 #include "braft/raft.h"                          // Closure
 #include "braft/configuration.h"                 // Configuration
@@ -57,6 +58,9 @@ struct ReplicatorOptions {
     SnapshotStorage* snapshot_storage;
     SnapshotThrottle* snapshot_throttle;
     ReplicatorStatus* replicator_status;
+
+    // Learner replciator do not vote.
+    bool is_learner;
 };
 
 typedef uint64_t ReplicatorId;
@@ -294,7 +298,7 @@ public:
     // NOTE: when calling this function, the replicatos starts to work
     // immediately, annd might call node->step_down which might have race with
     // the caller, you should deal with this situation.
-    int add_replicator(const PeerId& peer);
+    int add_replicator(const PeerId& peer, bool is_learner = false);
     
     // wait the very peer catchup
     int wait_caughtup(const PeerId& peer, int64_t max_margin,

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -5,7 +5,7 @@ cd ./build/test/
 for test_file in test_*; do
     if [[ -x "$test_file" ]]; then
         echo "Running $test_file ..."
-        ./"$test_file"
+        ./"$test_file" --minloglevel=2
     fi
 done
 

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd ./build/test/
+
+for test_file in test_*; do
+    if [[ -x "$test_file" ]]; then
+        echo "Running $test_file ..."
+        ./"$test_file"
+    fi
+done
+
+echo "All test done."
+


### PR DESCRIPTION
# 1. 一些关键细节

- **Learner 的元数据信息是没有持久化的**，Leader 崩溃重启后，不知道自己曾经有过从节点。
  - 这和 redis 的逻辑是一致的，Leader 崩溃重启后，从节点需要重新执行 salve of 来续上主从关系。
- **Learner 不支持直接切换成 Follower**。
  - 可以手动关闭主从关系，然后调用 NODE.JOIN 命令手动加入集群，这个方式对 braft 的修改最小，也不需要设计新的指令。
- **只有主节点能添加 Learner**，也就是说不允许从节点拥有从节点的场景，这个场景有需求吗？

# 2. 当前的改造方式

### 对于主节点的改造：

原理很简单：Node 类新增了一个成员，用于存储 Learner 的地址。

```C++
Configuration _learners;
```

Node 上新增了一个接口，用于为当前节点添加 Learner。

```C++
void Node::add_learner(const PeerId &peer, Closure *done); 
```

调用该接口时，如果当前节点是 Leader，即可成功添加一个新的 learner 类型的 replicator，并向其同步日志。

Learner 对应的 replicator 不会对日志投票，这样可以不修改 ballot_box 的代码，只需要给 replicator 添加一个标志位，表示该 replicator 是 learner 即可，该标志位在 replicator 启动时设置。

```C++
        if (!r->_options.is_learner) {
            r->_options.ballot_box->commit_at(
                    min_flying_index, rpc_last_log_index,
                    r->_options.peer_id);
        }
```

### 对 Learner 节点的支持

Node 节点中新增了一个 STATE_LEARNER 状态，Node 启动时可以以 Learner 状态启动。

```C++
enum State {
    STATE_LEARNER = 0,
    // ...
};

int NodeImpl::init(const NodeOptions& options) {
    // ...
    if (options.is_learner) {
        _state = STATE_LEARNER;
    } else {
        _state = STATE_FOLLOWER;
    }
    // ...
 }
```

STATE_LEARNER 状态的节点不会发起选举：

```C++
void NodeImpl::handle_election_timeout() {
    // ...
    if (_state != STATE_FOLLOWER) {
        return;
    }
```

STATE_LEARNER 状态的节点也不会参与选举，进行投票（通常情况下也不会收到 RequestVoteRPC）：

```C++
void NodeImpl::handle_request_vote_response(const PeerId& peer_id, const int64_t term,
                                            const int64_t ctx_version,
                                            const RequestVoteResponse& response) {
    // ...
    if (_state != STATE_CANDIDATE) {
        LOG(WARNING) << "node " << _group_id << ":" << _server_id
                     << " received invalid RequestVoteResponse from " << peer_id
                     << " state not in CANDIDATE but " << state2str(_state);
        return;
    }
```

braft 中的 Learner 不需要存储主节点的信息，主节点给 Learner 发送 AppendEntriesRPC 时，learner 会自动更新 leader ip。

# 3. TODO

- [ ] fixme：Learner 调用 step_down() 函数会被设置为 follower。
- [ ] 支持删除 Learner 的操作。
- [ ] 在 braft 单测框架下加入learner 的基本测试。
