### PR TITLE
feat: support generate checkpoint before replicator reader

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -249,6 +249,7 @@ int NodeImpl::init_snapshot_storage() {
     _snapshot_executor = new SnapshotExecutor;
     SnapshotExecutorOptions opt;
     opt.uri = _options.snapshot_uri;
+    opt.checkpoint_callback = _options.checkpoint_callback;
     opt.fsm_caller = _fsm_caller;
     opt.node = this;
     opt.log_manager = _log_manager;

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -20,6 +20,7 @@
 #ifndef BRAFT_RAFT_H
 #define BRAFT_RAFT_H
 
+#include <functional>
 #include <string>
 
 #include <butil/logging.h>
@@ -475,6 +476,9 @@ struct LeaderLeaseStatus {
     int64_t lease_epoch;
 };
 
+// Used to generate snapshots
+using CheckpointCallback = std::function<void(SnapshotWriter* writer)>;
+
 struct NodeOptions {
     // A follower would become a candidate if it doesn't receive any message 
     // from the leader in |election_timeout_ms| milliseconds
@@ -570,6 +574,9 @@ struct NodeOptions {
 
     // Describe a specific SnapshotStorage in format ${type}://${parameters}
     std::string snapshot_uri;
+
+    // Used to generate snapshots
+    CheckpointCallback checkpoint_callback;
 
     // If enable, we will filter duplicate files before copy remote snapshot,
     // to avoid useless transmission. Two files in local and remote are duplicate,

--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -794,7 +794,7 @@ void Replicator::_install_snapshot() {
     // blocked if something is wrong, such as throttled for a period of time 
     _st.st = INSTALLING_SNAPSHOT;
 
-    _reader = _options.snapshot_storage->open();
+    _reader = _options.snapshot_storage->open(true);
     if (!_reader) {
         if (_options.snapshot_throttle) {
             _options.snapshot_throttle->finish_one_task(true);

--- a/src/braft/snapshot.cpp
+++ b/src/braft/snapshot.cpp
@@ -671,8 +671,6 @@ int LocalSnapshotStorage::close(SnapshotWriter* writer_base,
 }
 
 SnapshotReader* LocalSnapshotStorage::open(bool is_replicator) {
-    std::unique_lock<raft_mutex_t> lck(_mutex);
-
     // After a follower joins a cluster, real snapshots need to be generated
     if (is_replicator && _checkpoint_callback) {
         SynchronizedClosure done;
@@ -685,6 +683,7 @@ SnapshotReader* LocalSnapshotStorage::open(bool is_replicator) {
         }
     }
 
+    std::unique_lock<raft_mutex_t> lck(_mutex);
     if (_last_snapshot_index != 0) {
         const int64_t last_snapshot_index = _last_snapshot_index;
         ++_ref_map[last_snapshot_index];

--- a/src/braft/snapshot_executor.h
+++ b/src/braft/snapshot_executor.h
@@ -36,6 +36,8 @@ struct SnapshotExecutorOptions {
     SnapshotExecutorOptions();
     // URI of SnapshotStorage
     std::string uri;
+    // Used to generate snapshots
+    CheckpointCallback checkpoint_callback;
    
     FSMCaller* fsm_caller;
     NodeImpl* node;
@@ -63,7 +65,7 @@ public:
 
     // Start to snapshot StateMachine, and |done| is called after the execution
     // finishes or fails.
-    void do_snapshot(Closure* done);
+    void do_snapshot(Closure* done, CheckpointCallback checkpoint_callback = nullptr);
 
     // Install snapshot according to the very RPC from leader
     // After the installing succeeds (StateMachine is reset with the snapshot)

--- a/src/braft/storage.h
+++ b/src/braft/storage.h
@@ -330,7 +330,7 @@ public:
     virtual int close(SnapshotWriter* writer) = 0;
 
     // get lastest snapshot reader
-    virtual SnapshotReader* open() = 0;
+    virtual SnapshotReader* open(bool is_replicator = false) = 0;
 
     // close snapshot reader
     virtual int close(SnapshotReader* reader) = 0;


### PR DESCRIPTION
1、方案：在options中添加了一个回调函数的参数点，把生成快照的回调函数通过这个参数传入到braft中，如果replicator在需要安装快照的时候，会在调用LocalSnapshotStorage::open函数中传入一个参数，标识是不是replicator调用的，然后根据这个标识和是否有回调函数，来决定do_snapshot的调用。
2、测试：
![8e076cff58bd8bf8942d6dcdb0a9923](https://github.com/pikiwidb/braft/assets/62509266/b94722fa-cc07-4484-93dd-8faf6271c80f)
3、改进：快照产生的流程放在更上层的pikiwidb中，install snapshot请求来了后，在那里调用一个node::snapshot函数，然后同步等运行完，那这里需要传进去的回调函数就是，给出当前的snapshot的 self sequence的callback。然后on_snapshot_save我们的回调本来是空的嘛，这里在done参数增加一个入参，用来决定是不是真的创建快照。这样on_snapshot_save和self_snapshot_index就完全对应上了。