### PR TITLE
fix: fixed a bug on supporting learners and added an interface for acquiring Learners

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -903,6 +903,15 @@ butil::Status NodeImpl::list_peers(std::vector<PeerId>* peers) {
     return butil::Status::OK();
 }
 
+butil::Status NodeImpl::list_learners(std::vector<PeerId>* learners) {
+    BAIDU_SCOPED_LOCK(_mutex);
+    if (_state != STATE_LEADER) {
+        return butil::Status(EPERM, "Not leader");
+    }
+    _learner_conf.conf.list_peers(learners);
+    return butil::Status::OK();
+}
+
 void NodeImpl::add_peer(const PeerId& peer, Closure* done) {
     BAIDU_SCOPED_LOCK(_mutex);
     Configuration new_conf = _conf.conf;

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -135,6 +135,7 @@ public:
     void apply(const Task& task);
 
     butil::Status list_peers(std::vector<PeerId>* peers);
+    butil::Status list_learners(std::vector<PeerId>* learners);
 
     // @Node configuration change
     void add_peer(const PeerId& peer, Closure* done);

--- a/src/braft/raft.cpp
+++ b/src/braft/raft.cpp
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <butil/string_printf.h>
 #include <butil/class_name.h>
+#include <vector>
 #include "braft/raft.h"
 #include "braft/node.h"
 #include "braft/storage.h"
@@ -184,6 +185,10 @@ void Node::apply(const Task& task) {
 
 butil::Status Node::list_peers(std::vector<PeerId>* peers) {
     return _impl->list_peers(peers);
+}
+
+butil::Status Node::list_learners(std::vector<PeerId>* learners) {
+    return _impl->list_learners(learners);
 }
 
 void Node::add_peer(const PeerId& peer, Closure* done) {

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -282,10 +282,10 @@ enum State {
 };
 
 inline const char* state2str(State state) {
-    const char* str[] = {"LEADER", "TRANSFERRING", "CANDIDATE", "FOLLOWER", 
+    const char* str[] = {"LEARNER", "LEADER", "TRANSFERRING", "CANDIDATE", "FOLLOWER", 
                          "ERROR", "UNINITIALIZED", "SHUTTING", "SHUTDOWN", };
     if (state < STATE_END) {
-        return str[(int)state - 1];
+        return str[(int)state];
     } else {
         return "UNKNOWN";
     }

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -689,6 +689,11 @@ public:
     // because add_peer/remove_peer immediately modify configuration in memory
     butil::Status list_peers(std::vector<PeerId>* peers);
 
+    // list learner peers of this raft group, only leader retruns ok
+    // [NOTE] when list_learner_peers concurrency with add_learner/remove_learner, maybe return learner_peers is staled.
+    // because add_learner/remove_learner immediately modify configuration in memory
+    butil::Status list_learners(std::vector<PeerId>* learners);
+
     // Add a new peer to the raft group. done->Run() would be invoked after this
     // operation finishes, describing the detailed result.
     void add_peer(const PeerId& peer, Closure* done);


### PR DESCRIPTION
该 pr 需要在 https://github.com/OpenAtomFoundation/pikiwidb/pull/342 之前合并
1. 原本支持 learner 的 pr 没有修改获取 learner state 部分的逻辑，导致获取 learner state 直接报错。
2. 新增了获取 learners 的接口，在支持主从模式下，需要获取集群中的 learners 的信息。