### PR TITLE
feat: support get configuration

### DIFF
--- a/src/braft/configuration_manager.cpp
+++ b/src/braft/configuration_manager.cpp
@@ -96,8 +96,8 @@ void ConfigurationManager::get(int64_t last_included_index,
 void ConfigurationManager::get_learner_conf(int64_t last_included_index,
                                ConfigurationEntry* conf) {
     if (_learner_configurations.empty()) {
-        CHECK_GE(last_included_index, _snapshot.id.index);
-        *conf = _snapshot;
+        CHECK_GE(last_included_index, _learner_snapshot.id.index);
+        *conf = _learner_snapshot;
         return;
     }
     std::deque<ConfigurationEntry>::iterator it;
@@ -107,7 +107,7 @@ void ConfigurationManager::get_learner_conf(int64_t last_included_index,
         }
     }
     if (it == _learner_configurations.begin()) {
-        *conf = _snapshot;
+        *conf = _learner_snapshot;
         return;
     }
     --it;

--- a/src/braft/fsm_caller.cpp
+++ b/src/braft/fsm_caller.cpp
@@ -561,10 +561,10 @@ void FSMCaller::describe(std::ostream &os, bool use_html) {
     os << newline;
 }
 
-void FSMCaller::set_self_playback_point(int64_t self_playback_point) {
-    _last_applied_index.store(self_playback_point,
-                              butil::memory_order_relaxed);
-    _last_applied_term = _log_manager->get_term(self_playback_point);
+void FSMCaller::set_last_applied_index_and_term(int64_t last_applied_index) {
+    _last_applied_index.store(last_applied_index,
+                                butil::memory_order_relaxed);
+    _last_applied_term = _log_manager->get_term(last_applied_index);
 }
 
 int64_t FSMCaller::applying_index() const {

--- a/src/braft/fsm_caller.h
+++ b/src/braft/fsm_caller.h
@@ -120,7 +120,7 @@ public:
     int64_t last_applied_index() const {
         return _last_applied_index.load(butil::memory_order_relaxed);
     }
-    void set_self_playback_point(int64_t self_playback_point);
+    void set_last_applied_index_and_term(int64_t last_applied_index);
     int64_t applying_index() const;
     void describe(std::ostream& os, bool use_html);
     void join();

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -979,13 +979,23 @@ butil::Status NodeImpl::reset_peers(const Configuration& new_peers) {
     return butil::Status::OK();
 }
 
-void NodeImpl::set_self_playback_point(int64_t self_playback_point) {
-    if (self_playback_point <= _fsm_caller->last_applied_index() || 
-        self_playback_point > _log_manager->last_log_index()) {
+void NodeImpl::set_last_applied_index_and_term(int64_t last_applied_index) {
+    if (last_applied_index <= _fsm_caller->last_applied_index() ||
+        last_applied_index > _log_manager->last_log_index()) {
         return;
     }
-    
-    _fsm_caller->set_self_playback_point(self_playback_point);
+
+    _fsm_caller->set_last_applied_index_and_term(last_applied_index);
+}
+
+void NodeImpl::get_configuration(const int64_t index, ConfigurationEntry *conf, ConfigurationEntry *learner_conf) {
+    if (conf != nullptr) {
+        _log_manager->get_configuration(index, conf);
+    }
+
+    if (learner_conf != nullptr) {
+        _log_manager->get_learner_configuration(index, learner_conf);
+    }
 }
 
 uint64_t NodeImpl::get_term(uint64_t log_index) {

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -145,7 +145,10 @@ public:
     butil::Status reset_peers(const Configuration& new_peers);
 
     // customize the log playback point
-    void set_self_playback_point(int64_t self_playback_point);
+    void set_last_applied_index_and_term(int64_t last_applied_index);
+
+    // get conf(include learners) by log index
+    void get_configuration(const int64_t index, ConfigurationEntry *conf, ConfigurationEntry *learner_conf);
 
     // get term by log index
     uint64_t get_term(uint64_t log_index);

--- a/src/braft/raft.cpp
+++ b/src/braft/raft.cpp
@@ -20,6 +20,7 @@
 #include <butil/string_printf.h>
 #include <butil/class_name.h>
 #include <vector>
+#include "braft/configuration_manager.h"
 #include "braft/raft.h"
 #include "braft/node.h"
 #include "braft/storage.h"
@@ -215,8 +216,12 @@ butil::Status Node::reset_peers(const Configuration& new_peers) {
     return _impl->reset_peers(new_peers);
 }
 
-void Node::set_self_playback_point(int64_t self_playback_point) {
-    _impl->set_self_playback_point(self_playback_point);
+void Node::set_last_applied_index_and_term(int64_t last_applied_index) {
+    _impl->set_last_applied_index_and_term(last_applied_index);
+}
+
+void Node::get_configuration(const int64_t index, ConfigurationEntry *conf, ConfigurationEntry *learner_conf) {
+    _impl->get_configuration(index, conf, learner_conf);
 }
 
 uint64_t Node::get_term(uint64_t log_index) {

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -45,6 +45,7 @@ class LeaderChangeContext;
 class FileSystemAdaptor;
 class SnapshotThrottle;
 class LogStorage;
+struct ConfigurationEntry;
 
 const PeerId ANY_PEER(butil::EndPoint(butil::IP_ANY, 0), 0);
 
@@ -724,7 +725,10 @@ public:
     butil::Status reset_peers(const Configuration& new_peers);
 
     // customize the log playback point
-    void set_self_playback_point(int64_t self_playback_point);
+    void set_last_applied_index_and_term(int64_t last_applied_index);
+
+    // get conf(include learners) by log index
+    void get_configuration(const int64_t index, ConfigurationEntry *conf, ConfigurationEntry *learner_conf);
 
     // get term by log index
     uint64_t get_term(uint64_t log_index);


### PR DESCRIPTION
1、支持通过 log index 来获取对应的成员配置。
2、修复实现 learner 中通过 log index 来获取 learner 配置的 bug。
3、修改 set_self_replay_point 接口名为 set_last_applied_index_and_term。
